### PR TITLE
ipTraceable ipValue is required

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -8,6 +8,7 @@ Doctrine ([Atlantic18/DoctrineExtensions](https://github.com/Atlantic18/Doctrine
 - [Configuration](#configuration)
     - [Loggable, Translatable, Treeable](#loggable-translatable-treeable)
     - [Translatable](#translatable)
+    - [IpTraceable](#iptraceable)
 
 ## Setup
 
@@ -84,4 +85,14 @@ nettrine.extensions.atlantic18:
         translationFallback: off
         persistDefaultTranslation: off
         skipOnLoad: off
+```
+
+### [IpTraceable](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/doc/ip_traceable.md)
+
+IpTraceable requires client IP address:
+
+```
+nettrine.extensions.atlantic18:
+    ipTraceable:
+        ipValue: @Nette\Http\IRequest::getRemoteAddress()
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Doctrine ([Atlantic18/DoctrineExtensions](https://github.com/Atlantic18/Doctrine
 - [Configuration](.docs/README.md#configuration)
     - [Loggable, Translatable, Treeable](.docs/README.md#loggable-translatable-treeable)
     - [Translatable](.docs/README.md#translatable)
-
+    - [IpTraceable](.docs/README.md##iptraceable)
+    
 ## Versions
 
 | State       | Version     | Branch   | Nette  | PHP    |

--- a/src/DI/Atlantic18BehaviorExtension.php
+++ b/src/DI/Atlantic18BehaviorExtension.php
@@ -13,6 +13,7 @@ use Gedmo\Timestampable\TimestampableListener;
 use Gedmo\Translatable\TranslatableListener;
 use Gedmo\Tree\TreeListener;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\Statement;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use stdClass;
@@ -43,7 +44,9 @@ class Atlantic18BehaviorExtension extends CompilerExtension
 			]))->default(false),
 			'uploadable' => Expect::bool(false),
 			'sortable' => Expect::bool(false),
-			'ipTraceable' => Expect::bool(false),
+			'ipTraceable' => Expect::anyOf(false, Expect::structure([
+				'ipValue' => Expect::anyOf(Expect::string(), Expect::array(), Expect::type(Statement::class))->required(),
+			]))->default(false),
 		]);
 	}
 
@@ -132,11 +135,11 @@ class Atlantic18BehaviorExtension extends CompilerExtension
 
 		// IpTraceable ===============================================
 
-		if ($config->ipTraceable) {
+		if ($config->ipTraceable !== false) {
 			$builder->addDefinition($this->prefix('ipTraceable'))
 				->setFactory(IpTraceableListener::class)
 				->addSetup('setAnnotationReader', ['@' . Reader::class])
-				->addSetup('setIpValue', !empty($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null)
+				->addSetup('setIpValue', $config->ipTraceable->ipValue)
 				->addTag(self::TAG_NETTRINE_SUBSCRIBER);
 		}
 	}


### PR DESCRIPTION
Previous fix #15 didn't consider usage behind proxy when `$_SERVER['REMOTE_ADDR']` is not user ip and also it was set in compile-time, so ip address of user for which was container first compiled was always used. Better be explicit.

cc @mark-31 